### PR TITLE
[MyPerf4J-101] Fix flaky test testMultiThread4HighRace and testMultiThread4LowRace #101

### DIFF
--- a/MyPerf4J-Base/src/test/java/cn/myperf4j/base/util/concurrent/AtomicIntHashCounterTest.java
+++ b/MyPerf4J-Base/src/test/java/cn/myperf4j/base/util/concurrent/AtomicIntHashCounterTest.java
@@ -162,7 +162,17 @@ public class AtomicIntHashCounterTest {
 
     @Test
     public void testMultiThread4HighRace() throws InterruptedException, BrokenBarrierException {
-        final int threadCnt = Runtime.getRuntime().availableProcessors() - 2;
+        //final int threadCnt = Runtime.getRuntime().availableProcessors() - 2;
+        final int availableThreads = Runtime.getRuntime().availableProcessors();
+        int threadCnt;
+        if (availableThreads <= 1) {
+            throw new RuntimeException("Multithreading is not supported on this system with " +
+                    availableThreads + " available processors.");
+        } else if (availableThreads >= 2 && availableThreads <= 3) {
+            threadCnt = 2;
+        } else {
+            threadCnt = availableThreads - 2;
+        }
         final ExecutorService executor = Executors.newFixedThreadPool(threadCnt);
         int failureTimes = 0;
 //        final int testTimes = 1024 * 1024;
@@ -184,7 +194,16 @@ public class AtomicIntHashCounterTest {
 
     @Test
     public void testMultiThread4LowRace() throws InterruptedException, BrokenBarrierException {
-        final int threadCnt = Runtime.getRuntime().availableProcessors() - 2;
+        final int availableThreads = Runtime.getRuntime().availableProcessors();
+        int threadCnt;
+        if (availableThreads <= 1) {
+            throw new RuntimeException("Multithreading is not supported on this system with " +
+                    availableThreads + " available processors.");
+        } else if (availableThreads >= 2 && availableThreads <= 3) {
+            threadCnt = 2;
+        } else {
+            threadCnt = availableThreads - 2;
+        }
         final ExecutorService executor = Executors.newFixedThreadPool(threadCnt);
         int failureTimes = 0;
 //        final int testTimes = 1024 * 1024;


### PR DESCRIPTION
## What is the purpose of the change

Fix [#101](https://github.com/LinShunKang/MyPerf4J/issues/101#issue-1941228158)

## Brief ChangeLog

1. Test Overview:
    Location: `Myperf4j-Base/util/concurrent/AtomicIntHashCounterTest.java`
    Test : `testMultiThread4HighRace` and `testMultiThread4LowRace`

    The two test are designed to assess the behavior of a multi-threaded scenario with varying levels of contention, and they use random parameters to perform a large number of iterations to test the stability and correctness of the tested code. 


2. Reason of flakiness:
    `ExecutorService newFixedThreadPool(int nThreads)` method creates a thread pool that reuses a fixed number of threads operating off a shared unbounded queue. And it will throw error message `IllegalArgumentException` if `nThreads <= 0`.
The author initially set the `threadCnt` to `availableProcessors() - 2` to maybe avoid occupying too many computing resources. However, when the machine we use has less than 2 processors, an error will arise.

3. Changes:

- Introduced a new variable `availableThreads` to store the number of available processors.
- Added conditional check to `threadCnt` to handle cases with different number of available processors.
    - If the machine has less than 2 available processors, it throws an error message indicating that multithreading is not supported
    - If the machine has 2 or 3 available processors, it use 2 threads for testing.
    - For all other cases, it use `availableThreads - 2` threads, which is consistent with the original code.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Make sure there is a [GITHUB_issue](https://github.com/LinShunKang/MyPerf4J/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GITHUB issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [X] Format the pull request title like `[MyPerf4J-XXX] Fix NullPointerException when host is null #XXX`. Each commit in the pull request should have a meaningful subject line and body.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist.
- [X] Run `mvn clean package -Dmaven.test.skip=false` to make sure unit-test pass.